### PR TITLE
Fix: deadlock happens when message queue is full

### DIFF
--- a/lib/utlt/src/utlt_timer.c
+++ b/lib/utlt/src/utlt_timer.c
@@ -62,14 +62,14 @@ void TimerListInit(TimerList *tmList) {
 
 // Check expire time and update active and idle list
 Status TimerExpireCheck(TimerList *tmList, uintptr_t data) {
-    pthread_mutex_lock(&tmList->lock);
     uint32_t curTime = TimeMsec(TimeNow());
     TimerBlk *tm = ListFirst(&(tmList->active));
 
     while (tm != (TimerBlk *)&tmList->active) {
         if (tm->expireTime < curTime) {
             tm->expireFunc(data, tm->param);
-            
+            pthread_mutex_lock(&tmList->lock);
+
             if (tm->isRunning) {
                 ListRemove(tm);
 
@@ -84,11 +84,11 @@ Status TimerExpireCheck(TimerList *tmList, uintptr_t data) {
                 }
             }
             tm = ListFirst(&(tmList->active));
+            pthread_mutex_unlock(&tmList->lock);
         } else {
             break;
         }
     }
-    pthread_mutex_unlock(&tmList->lock);
     return STATUS_OK;
 }
 


### PR DESCRIPTION
## Description
TimerExpireCheck runs periodically, but when Message Queue is full it acquires mutex lock of tmList and is blocked in the EventTimerExpire function. 

but  eventConsumer thread handle N4 event and try to handle EventTimer at the same time, it cannnot acquire this mutex lock in EventTimerCreate or TimerDelete functions and then deadlock happens.

## relating issue

https://github.com/free5gc/free5gc/issues/218